### PR TITLE
修改阿里云的库 require 'typhoeus/adapters/faraday'

### DIFF
--- a/lib/aliyun/sms.rb
+++ b/lib/aliyun/sms.rb
@@ -1,7 +1,7 @@
 require "aliyun/sms/version"
 require "openssl"
 require "base64"
-require "typhoeus"
+require 'typhoeus/adapters/faraday'
 require "erb"
 include ERB::Util
 


### PR DESCRIPTION
否则使用 elasticsearch 的时候，会报错
Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid #11