### PR TITLE
Update implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ You might be using services other than aliyun-sms, but **this gem only for aliyu
 
 Before using aliyun-sms, you must apply and enable the aliyun-sms service, parameters as follows are **required**:
 
-1. ACCESS\_KEY\_SECRET：   apply it on aliyun console
-2. ACCESS\_KEY\_ID：       apply it on aliyun console
-3. SIGN\_NAME：            defined in aliyun-sms
-4. TEMPLATE\_CODE：        defined in aliyun-sms
+1. `ACCESS_KEY_SECRET`: apply it on aliyun console
+2. `ACCESS_KEY_ID`: apply it on aliyun console
+3. `SIGN_NAME`: defined in aliyun-sms
+4. `TEMPLATE_CODE`: defined in aliyun-sms
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the following line in Gemfile :
 gem 'aliyun-sms'
 ```
 
-Then Run the following command:
+Then run the following command:
 
 ```ruby
 bundle

--- a/README.md
+++ b/README.md
@@ -1,56 +1,57 @@
 ## [中文说明](./README.zh-CN.md)
 
-# Aliyun::Sms  Ruby Gem for Aliyun Short Message Service(aliyun-sms)
+# An **UNOFFICIAL** Aliyun SMS RubyGem
 
-**Comfortable to aliyun sms  *2017-05-25 version* api**
+**Compatible with Aliyun SMS *2017-05-25 version* API**
 
 ## Notice
 
-Currently, aliyun has three services of short message，named：
+Currently, Aliyun has three different services of SMS：
 
-1. ali-dayu(阿里大于)
-2. aliyun-mq(阿里云消息队列)
-3. aliyun-sms(阿里云短信服务)
+1. ali-dayu (阿里大于)
+2. aliyun-mq (阿里云消息队列)
+3. aliyun-sms (阿里云短信服务)
 
-They all are usable, and will merge togather in future. But before merged, they are Independent, and every user only use one between them.
+All of these services are currently available, but would be merged into a single product in the future.
 
-**This gem only for aliyun-sms(阿里云短信服务), and you must confirm that you just use it. If you can't confirm, please see the document [阿里云短信业务说明](https://help.aliyun.com/document_detail/63097.html?spm=a2c4g.11186623.6.542.6fZlRU) to get guidance.**
+You might be using services other than aliyun-sms, but **this gem only for aliyun-sms (阿里云短信服务) ONLY**.
 
-## Before
+**Check Aliyun Official Documentation [阿里云短信业务说明](https://help.aliyun.com/document_detail/63097.html?spm=a2c4g.11186623.6.542.6fZlRU) for details.**
 
-Before use aliyun-sms, you must apply and open the aliyun-sms, and get the parameters as follows:
+## Requirements
 
-1. ACCESS\_KEY\_SECRET：   apply on aliyun console
-2. ACCESS\_KEY\_ID：       apply on aliyun console
-3. SIGN\_NAME：            get when open the aliyun-sms
-4. TEMPLATE\_CODE：        get when open the aliyun-sms
+Before using aliyun-sms, you must apply and enable the aliyun-sms service, parameters as follows are **required**:
+
+1. ACCESS\_KEY\_SECRET：   apply it on aliyun console
+2. ACCESS\_KEY\_ID：       apply it on aliyun console
+3. SIGN\_NAME：            defined in aliyun-sms
+4. TEMPLATE\_CODE：        defined in aliyun-sms
 
 ## Installation
 
-### Ruby Common Method
-
+### Gem
 
 ```ruby
 gem install aliyun-sms
 ```
 
-### Rails Method
+### With Bundler
 
-Add in Gemfile :
+Add the following line in Gemfile :
 
 ```ruby
-gem 'aliyun-sms'   # Ruby Gems 安装源
+gem 'aliyun-sms'
 ```
 
-Run command:
+Then Run the following command:
 
 ```ruby
 bundle
 ```
 
-### Download Method
+### Manual Installation
 
-Clone and install by rake.
+Clone and install the gem by rake.
 
 ```bash
 git clone https://github.com/VICTOR-LUO-F/aliyun-sms.git
@@ -62,7 +63,7 @@ rake build
 rake install
 ```
 
-### Problem and Resolve
+### FAQ
 
 ```ruby
 require 'aliyun/sms'
@@ -72,73 +73,50 @@ If you get a error as follows, when running above command：
 
 > ./config/initializers/aliyun-sms.rb:1:in `<top (required)>': uninitialized constant Aliyun::Sms (NameError)
 
-You could switch to github resource, and modify the the Rails Gemfile to:
-
-```ruby
-gem 'aliyun-sms', '1.1.1', git: 'https://github.com/VICTOR-LUO-F/aliyun-sms.git'
-```
+Update your Gem to a later version.
 
 ## Usage
 
-### Ruby Common Program（irb）
-
-#### First Step：
-
-```bash
-$ require 'aliyun/sms'
-```
-
-return
-
-```bash
-=> true
-```
-
-#### Second Step：
-
+### Basic Usages
 
 ```ruby
-$ Aliyun::Sms.configure do |config|
-    config.access_key_secret = ACCESS_KEY_SECRET    
-    config.access_key_id = ACCESS_KEY_ID            
-    config.action = 'SendSms'                       # default value
-    config.format = 'XML'                           # http return format, value is 'JSON' or 'XML'
-    config.region_id = 'cn-hangzhou'                # default value      
-    config.sign_name = SIGN_NAME                  
-    config.signature_method = 'HMAC-SHA1'           # default value
-    config.signature_version = '1.0'                # default value
-    config.version = '2017-05-25'                   # default value
-  end
+require 'aliyun/sms'
 
+Aliyun::Sms.configure do |config|
+  config.access_key_secret = ACCESS_KEY_SECRET    
+  config.access_key_id = ACCESS_KEY_ID            
+  config.action = 'SendSms'                       # default value
+  config.format = 'XML'                           # http return format, value is 'JSON' or 'XML'
+  config.region_id = 'cn-hangzhou'                # default value      
+  config.sign_name = SIGN_NAME                  
+  config.signature_method = 'HMAC-SHA1'           # default value
+  config.signature_version = '1.0'                # default value
+  config.version = '2017-05-25'                   # default value
+end
 ```
-return
-
-```ruby
-  => "2017-05-25"
-```
-
-#### Third Step：
 
 Send message：
 
-    $ Aliyun::Sms.send(phone_numbers, template_code, template_param, out_id)
+```ruby
+Aliyun::Sms.send(phone_numbers, template_code, template_param, out_id)
+```
 
-Explanation：
+Parameters:
 
-1. phone_numbers： the phone number, string type, such as '1234567890'. You can use multiple phone numbers devided by comma, such as '1234567890,12388888888'.
-2. template\_code： message template code, string type, such as 'SMS_12345678'.
-3. template_param： message template params, tring type, such as '{"code":"666666", "product":"content" }'.
-4. out_id：out extension id，string type，could be null。
+1. phone_numbers: the phone number, string type, such as '1234567890'. You can use multiple phone numbers devided by comma, such as '1234567890,12388888888'.
+2. template_code: message template code, string type, such as 'SMS_12345678'.
+3. template_param: message template params, tring type, such as '{"code":"666666", "product":"content" }'.
+4. out_id: out extension id，string type，could be `nil`.
 
 
 ### Rails Application
 
-#### First Step：
+#### Initialization
 
-In Rails direction 'config/initializers/', create file 'aliyun-sms.rb', and add code：           
+In Rails directory 'config/initializers/', create the file 'aliyun-sms.rb', and add the following code：           
 
 
-config/initializers/aliyun-sms.rb
+`config/initializers/aliyun-sms.rb`
 
 ```ruby
 Aliyun::Sms.configure do |config|
@@ -153,11 +131,11 @@ Aliyun::Sms.configure do |config|
   config.version = '2017-05-25'                   # default value
 end
 ```
-then, restart Rails application。
+then, restart your Rails application。
 
-#### Second Step：
+#### Send Messages
 
-Send message in your program：
+Send your message in your program:
 
 ```ruby
 Aliyun::Sms.send(phone_numbers, template_code, template_param, out_id)
@@ -165,31 +143,31 @@ Aliyun::Sms.send(phone_numbers, template_code, template_param, out_id)
 
 Explanation：
 
-1. phone_numbers： the phone number, string type, such as '1234567890'. You can use multiple phone numbers devided by comma, such as '1234567890,12388888888'.
-2. template\_code： message template code, string type, such as 'SMS_12345678'.
-3. template_param： message template params, tring type, such as '{"code":"666666", "product":"content" }'.
-4. out_id：out extension id，string type，could be null。
+1. phone_numbers: the phone number, string type, such as '1234567890'. You can use multiple phone numbers devided by comma, such as '1234567890,12388888888'.
+2. template_code: message template code, string type, such as 'SMS_12345678'.
+3. template_param: message template params, tring type, such as '{"code":"666666", "product":"content" }'.
+4. out_id: out extension id，string type，could be `nil`.
 
-Specially：
+NOTICE:
 
-In Rails application program, you could organize your message content as a hash, and trans it bo be a param of Aliyun::Sms.send by to_json method. For instance:
+Since the `template_param` is a string, convert the hash into json string before calling the method.
 
 ```ruby
 ...
 phone_number = '1234567890'
 template_code = 'SMS_12345678'
-template_param = {"code"=>"666666", "product"=>"conten" }.to_json
+template_param = {"code"=>"666666", "product"=>"content" }.to_json
 Aliyun::Sms.send(phone_numbers, template_code, template_param)
 ...
 ```    
 
-## Development
+## Test
 
-According to [Aliyun Official Document](https://help.aliyun.com/document_detail/56189.html?spm=a2c4g.11186623.6.580.o8Fm0S) example, I had written spect test. You could run the test after clone as follows:
+Spec tests covered the example provied in the [Aliyun Official Document](https://help.aliyun.com/document_detail/56189.html?spm=a2c4g.11186623.6.580.o8Fm0S). You could run the test after clone as follows:
 
     $ bundle exec rspec spec
 
 
 ## License
 
-MIT License。 [MIT License](http://opensource.org/licenses/MIT).
+[MIT License](http://opensource.org/licenses/MIT).

--- a/aliyun-sms.gemspec
+++ b/aliyun-sms.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_dependency "typhoeus"
+  spec.add_dependency "faraday"
 end

--- a/spec/aliyun_sms_spec.rb
+++ b/spec/aliyun_sms_spec.rb
@@ -1,35 +1,10 @@
 require 'aliyun/sms'
+
+def params_str(params)
+  URI.encode_www_form(params.sort.to_h)
+end
+
 describe Aliyun::Sms do
-
-  describe "#top test" do
-    before do
-      Aliyun::Sms.configure do |config|
-        config.access_key_secret = 'testSecret'
-        config.access_key_id = 'testId'
-        config.action = 'SendSms'
-        config.format = 'XML'
-        config.region_id = 'cn-hangzhou'
-        config.sign_name = '阿里云短信测试专用'
-        config.signature_method = 'HMAC-SHA1'
-        config.signature_version = '1.0'
-        config.version = '2017-05-25'
-      end
-    end
-
-    it "get the http query url" do
-      user_params = {
-        'SignatureNonce' => '45e25e9b-0a6f-4070-8c85-2956eda1b466',
-        'TemplateCode' => 'SMS_71390007',
-        'Timestamp' => '2017-07-12T02:42:19Z',
-        'PhoneNumbers' =>	'15300000001',
-        'TemplateParam' => '{"customer":"test"}',
-        'OutId'	=> '123'
-      }
-      spect_output = 'http://dysmsapi.aliyuncs.com/?Signature=zJDF%2BLrzhj%2FThnlvIToysFRq6t4%3D&AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=%E9%98%BF%E9%87%8C%E4%BA%91%E7%9F%AD%E4%BF%A1%E6%B5%8B%E8%AF%95%E4%B8%93%E7%94%A8&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam=%7B%22customer%22%3A%22test%22%7D&Timestamp=2017-07-12T02%3A42%3A19Z&Version=2017-05-25'
-      expect(Aliyun::Sms.get_url(user_params)).to eql(spect_output)
-    end
-  end
-
   describe "#configure" do
     before do
       Aliyun::Sms.configure do |config|
@@ -43,29 +18,6 @@ describe Aliyun::Sms do
         config.signature_version = '1.0'
         config.version = '2017-05-25'
       end
-    end
-
-    it "get query string through configurated itmes" do
-      config = Aliyun::Sms.configuration
-      method_input = {
-        'AccessKeyId' => config.access_key_id,
-        'Action' => config.action,
-        'Format' => config.format,
-        'RegionId' => config.region_id,
-        'SignName' => config.sign_name,
-        'SignatureMethod' => config.signature_method,
-        'SignatureVersion' => config.signature_version,
-        'Version' => config.version,
-        'SignatureNonce' => '45e25e9b-0a6f-4070-8c85-2956eda1b466',
-        'TemplateCode' => 'SMS_71390007',
-        'Timestamp' => '2017-07-12T02:42:19Z',
-        'PhoneNumbers' =>	'15300000001',
-        'TemplateParam' => '{"customer":"test"}',
-        'OutId'	=> '123'
-      }
-      spect_output = 'AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=阿里云短信测试专用&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam={"customer":"test"}&Timestamp=2017-07-12T02:42:19Z&Version=2017-05-25'
-
-      expect(Aliyun::Sms.test_query_string(method_input)).to eql(spect_output)
     end
   end
 
@@ -84,7 +36,7 @@ describe Aliyun::Sms do
       end
     end
 
-    it "get query params string by merge configed params and user params" do
+    it "gets query params string by merge configed params and user params" do
       #config = Aliyun::Sms.configuration
       user_params = {
         'SignatureNonce' => '45e25e9b-0a6f-4070-8c85-2956eda1b466',
@@ -95,36 +47,12 @@ describe Aliyun::Sms do
         'OutId'	=> '123'
       }
 
-      spect_output = 'AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=阿里云短信测试专用&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam={"customer":"test"}&Timestamp=2017-07-12T02:42:19Z&Version=2017-05-25'
-      get_params = Aliyun::Sms.get_params(user_params)
-      expect(Aliyun::Sms.test_query_string(get_params)).to eql(spect_output)
+      expected = 'AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=%E9%98%BF%E9%87%8C%E4%BA%91%E7%9F%AD%E4%BF%A1%E6%B5%8B%E8%AF%95%E4%B8%93%E7%94%A8&Signature=zJDF%252BLrzhj%252FThnlvIToysFRq6t4%253D&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam=%7B%22customer%22%3A%22test%22%7D&Timestamp=2017-07-12T02%3A42%3A19Z&Version=2017-05-25'
+      expect(params_str(Aliyun::Sms.get_params(user_params))).to eql(expected)
     end
   end
 
-  it "get the canonicalized query string" do
-    method_input = {
-      'AccessKeyId' => 'testId',
-      'Action' => 'SendSms',
-      'Format' => 'XML',
-      'RegionId' => 'cn-hangzhou',
-      'SignName' => '阿里云短信测试专用',
-      'SignatureMethod' => 'HMAC-SHA1',
-      'SignatureVersion' => '1.0',
-      'Version' => '2017-05-25',
-      'SignatureNonce' => '45e25e9b-0a6f-4070-8c85-2956eda1b466',
-      'TemplateCode' => 'SMS_71390007',
-      'Timestamp' => '2017-07-12T02:42:19Z',
-      'PhoneNumbers' =>	'15300000001',
-      'TemplateParam' => '{"customer":"test"}',
-      'OutId'	=> '123'
-    }
-
-    spect_output = 'AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=%E9%98%BF%E9%87%8C%E4%BA%91%E7%9F%AD%E4%BF%A1%E6%B5%8B%E8%AF%95%E4%B8%93%E7%94%A8&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam=%7B%22customer%22%3A%22test%22%7D&Timestamp=2017-07-12T02%3A42%3A19Z&Version=2017-05-25'
-
-    expect(Aliyun::Sms.canonicalized_query_string(method_input)).to eql(spect_output)
-  end
-
-  it "get sign" do
+  it "signs" do
     params_input = {
       'AccessKeyId' => 'testId',
       'Action' => 'SendSms',
@@ -142,10 +70,8 @@ describe Aliyun::Sms do
       'OutId'	=> '123'
     }
     key = 'testSecret'
-    spect_output = 'zJDF%2BLrzhj%2FThnlvIToysFRq6t4%3D'
-    coded_params = 'AccessKeyId=testId&Action=SendSms&Format=XML&OutId=123&PhoneNumbers=15300000001&RegionId=cn-hangzhou&SignName=%E9%98%BF%E9%87%8C%E4%BA%91%E7%9F%AD%E4%BF%A1%E6%B5%8B%E8%AF%95%E4%B8%93%E7%94%A8&SignatureMethod=HMAC-SHA1&SignatureNonce=45e25e9b-0a6f-4070-8c85-2956eda1b466&SignatureVersion=1.0&TemplateCode=SMS_71390007&TemplateParam=%7B%22customer%22%3A%22test%22%7D&Timestamp=2017-07-12T02%3A42%3A19Z&Version=2017-05-25'
+    expected = 'zJDF%2BLrzhj%2FThnlvIToysFRq6t4%3D'
 
-    expect(Aliyun::Sms.sign(key, coded_params)).to eql(spect_output)
+    expect(Aliyun::Sms.sign(key, params_input)).to eql(expected)
   end
-
 end


### PR DESCRIPTION
1. `Typheous` is no longer under active development, use `Faraday` instead.
2. Use `https` by default instead of `http` request.
3. Simplify the whole process of encoding and signing.
4. Update and fix typo grammar problems in the English docs.
---
1. `Typheous` 已经不再处于积极维护状态，改为使用 `Faraday`
2. 默认使用了 `https` 而不是 `http` 协议
3. 极大简化了编码和签名的逻辑实现
4. 更新并修复了英语文档中的大量拼写和语法问题